### PR TITLE
Add reference to reliable_text in the official FreeDV specs.

### DIFF
--- a/demo/freedv_700d_rx.c
+++ b/demo/freedv_700d_rx.c
@@ -4,7 +4,7 @@
   AUTHOR......: David Rowe
   DATE CREATED: April 2021
 
-  Demo receive program for FreeDV API 700D mode, see freedv_700d_tx.c for
+  Demo receive program for FreeDV API (700D mode), see freedv_700d_tx.c for
   instructions.
  
 \*---------------------------------------------------------------------------*/

--- a/demo/freedv_700d_tx.c
+++ b/demo/freedv_700d_tx.c
@@ -4,7 +4,7 @@
   AUTHOR......: David Rowe
   DATE CREATED: April 2021
 
-  Demo transmit program for FreeDV API 700D functions.
+  Demo transmit program using the FreeDV API (700D mode).
  
   usage:
   

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -9,7 +9,8 @@
 
   1. README_freedv.md
   2. Notes on function use in freedv_api.c
-  3. The sample freedv_tx.c and freedv_rx.c programs
+  3. Simple demo programs in the "demo" directory
+  4. The full featured command line freedv_tx.c and freedv_rx.c programs
 
 \*---------------------------------------------------------------------------*/
 


### PR DESCRIPTION
As the subject states. Probably a good idea to do a pass through too and make sure this is fully up to date in general.